### PR TITLE
Upgrade discipl/law-reg

### DIFF
--- a/compliance-by-design-demo/package-lock.json
+++ b/compliance-by-design-demo/package-lock.json
@@ -1219,9 +1219,9 @@
       }
     },
     "@discipl/law-reg": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@discipl/law-reg/-/law-reg-0.5.7.tgz",
-      "integrity": "sha512-XaobQv4Xk9lVAb1B6sZwQdIWqJkxOcEtUB0UdvtlqI0LWgLImiT7A/vGuG9Fz/DW//Hg+/vtEtNIKSu+xJ5UxA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@discipl/law-reg/-/law-reg-0.6.0.tgz",
+      "integrity": "sha512-B+5GCqVP10lQt0IbwOpOSPmjLME/SBvDYJ9XVWGt3616MYWRKEZM5/alWJJhHM43V3PPn4XUFDANsE1RB2/92g==",
       "requires": {
         "@discipl/abundance-service": "0.5.0",
         "@discipl/core-baseconnector": "0.2.1",

--- a/compliance-by-design-demo/package.json
+++ b/compliance-by-design-demo/package.json
@@ -7,7 +7,7 @@
   "homepage": "./",
   "dependencies": {
     "@discipl/core-ephemeral": "^0.11.0",
-    "@discipl/law-reg": "^0.5.7",
+    "@discipl/law-reg": "^0.6.0",
     "loglevel": "^1.6.3",
     "papaparse": "^5.0.0",
     "prop-types": "^15.7.2",

--- a/compliance-by-design-demo/src/components/ActorView.js
+++ b/compliance-by-design-demo/src/components/ActorView.js
@@ -207,7 +207,6 @@ class ActorView extends Component {
 
   async askFact(
     fact,
-    _flintItem,
     _listNames,
     _listIndices,
     possibleCreatingActions

--- a/compliance-by-design-demo/src/components/ActorView.js
+++ b/compliance-by-design-demo/src/components/ActorView.js
@@ -205,12 +205,7 @@ class ActorView extends Component {
     }
   }
 
-  async askFact(
-    fact,
-    _listNames,
-    _listIndices,
-    possibleCreatingActions
-  ) {
+  async askFact(fact, _listNames, _listIndices, possibleCreatingActions) {
     console.log("in askFact");
     if (
       this.props.derivedFacts &&

--- a/compliance-by-design-demo/src/model/tegemoetkoming-schade-covid19.flint.json
+++ b/compliance-by-design-demo/src/model/tegemoetkoming-schade-covid19.flint.json
@@ -659,7 +659,9 @@
     },
     {
       "fact": "[besluit tot inwilligen aanvraag tegemoetkoming in de schade geleden door de maatregelen ter bestrijding van de verdere verspreiding van COVID-19]",
-      "function": "<<>>",
+      "function": {
+        "expression": "CREATE"
+      },
       "sources": [],
       "explanation": ""
     },


### PR DESCRIPTION
This PR upgrades to `@discipl/discipl-law-reg@0.6.0` and fixes code that is broke due to this upgrade. On summary:
- All `<<>>` notation are replaced by the `CREATE` expression
- The `_flintItem` parameter is not longer in use and thus needs to be removed to access the other parameters correctly